### PR TITLE
Add msec-docs-bot[bot] to CLA bypassUsers

### DIFF
--- a/policies/cla.yml
+++ b/policies/cla.yml
@@ -119,6 +119,7 @@ configuration:
          - VSC-Service-Account
          - wsd-ram-github-app[bot]
          - docsautomation[bot]
+         - msec-docs-bot[bot]
          - Copilot
          - Copilot[bot]
          - linkedin-api-docs-pull-back-bot[bot]


### PR DESCRIPTION
Adds `msec-docs-bot[bot]` to the CLA `bypassUsers` list.

`msec-docs-bot[bot]` opens automated editorial-fix PRs against the docs PR repos. Every PR it opens currently gets `do-not-merge` until a human pastes the `@microsoft-github-policy-service agree` reply — blocking the bot's normal flow.

Placed next to `docsautomation[bot]` — same trust class as existing entries like `prmerger-automation[bot]`, `learn-build-service-prod[bot]`, `openpublishbuild`.

Happy to verify App ownership over a non-public channel.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
